### PR TITLE
Add support for Unicode characters AB-9690

### DIFF
--- a/lib/action_sms/providers/cool_sms.rb
+++ b/lib/action_sms/providers/cool_sms.rb
@@ -6,6 +6,7 @@ module ActionSms
       DELIVERED_OK = "SMS sent"
       DELIVER_EXCEPTION = "Exception: %s"
       SMS_GATEWAY_ERROR = "SMS Gateway Error Code: %s"
+      FORMAT = 'UNICODE'
 
       def self.deliver(message)
         all_ok = false
@@ -20,7 +21,8 @@ module ActionSms
             message: {
               recipients: phone_number,
               sender: from,
-              message: message.body
+              message: message.body,
+              format: FORMAT
             }
           }
 
@@ -29,7 +31,7 @@ module ActionSms
             body[:message][:statusurl] = message.status_report_url
           end
 
-          response = RestClient.post(url, body.to_json, content_type: 'application/json')
+          response = RestClient.post(url, body.to_json, content_type: 'application/json; charset=utf-8')
 
           all_ok = response.code == 201
           if all_ok


### PR DESCRIPTION
[Jira Ticket](https://autobutler.atlassian.net/browse/AB-9690)

Certain French characters were being displayed as `?` in messages. This was because we were using the default `GSM` message format. This has now been changed to `UNICODE`.

This reduces the maximum number of characters per message part. This does not mean that we send two messages if we have gone over the lower limit, we just send two payloads which are then stitched together.

Api documentation on the configuration changed:
https://linkmobility.atlassian.net/wiki/spaces/COOL/pages/26017807/08.+Messages